### PR TITLE
Update CLI to allow explicit naming of -i -o files.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 'use strict';
 var fs = require('fs');
 var strip = require('./strip-json-comments');
-var input = process.argv[2];
+var input, output;
 
 
 function getStdin(cb) {
@@ -19,10 +19,20 @@ function getStdin(cb) {
 	});
 }
 
+function writeStdout(data, output) {
+	if (output) {
+		fs.writeFile(output, data);
+	} else {
+		process.stdout.write(data);
+	}
+}
+
 if (process.argv.indexOf('-h') !== -1 || process.argv.indexOf('--help') !== -1) {
 	console.log('strip-json-comments input-file > output-file');
 	console.log('or');
 	console.log('strip-json-comments < input-file > output-file');
+	console.log('or');
+	console.log('strip-json-comments -i input-file -o output-file');
 	return;
 }
 
@@ -31,11 +41,21 @@ if (process.argv.indexOf('-v') !== -1 || process.argv.indexOf('--version') !== -
 	return;
 }
 
+if (process.argv.indexOf('-i') !== -1) {
+	input = process.argv[process.argv.indexOf('-i') + 1];
+} else if (process.argv[2] && process.argv[2].substring(0, 1) !== '-') {
+	input = process.argv[2];
+}
+
+if (process.argv.indexOf('-o') !== -1) {
+	output = process.argv[process.argv.indexOf('-o') + 1];
+}
+
 if (input) {
-	process.stdout.write(strip(fs.readFileSync(input, 'utf8')));
+	writeStdout(strip(fs.readFileSync(input, 'utf8')), output);
 	return;
 }
 
 getStdin(function (data) {
-	process.stdout.write(strip(data));
+	writeStdout(strip(data), output);
 });

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ This is now possible:
 ```js
 {
 	// rainbows
-	"unicorn": /* â?¤ */ "cake"
+    "unicorn": /* â¤ */ "cake"
 }
 ```
 
@@ -68,7 +68,7 @@ strip-json-comments input-file > output-file
 # or
 strip-json-comments < input-file > output-file
 # or
-strip-json-comments -i <input-file> -o <output-file>
+strip-json-comments -i input-file -o output-file
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -15,8 +15,9 @@ It will remove single-line comments `//` and multi-line comments `/**/`.
 
 Also available as a [gulp](https://github.com/sindresorhus/gulp-strip-json-comments)/[grunt](https://github.com/sindresorhus/grunt-strip-json-comments)/[broccoli](https://github.com/sindresorhus/broccoli-strip-json-comments) plugin and a [require hook](https://github.com/uTest/autostrip-json-comments).
 
+-
 
-*There's already [json-comments](https://npmjs.org/package/json-comments), but it's only for Node.js and uses a naive regex to strip comments which fails on simple cases like `{"a":"//"}`. This module however parses out the comments.*
+*There's also [`json-comments`](https://npmjs.org/package/json-comments), but it's only for Node.js, inefficient, bloated as it also minifies, and comes with a `require` hook, which is :(*
 
 
 ## Install

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,8 @@ $ strip-json-comments --help
 strip-json-comments input-file > output-file
 # or
 strip-json-comments < input-file > output-file
+# or
+strip-json-comments -i <input-file> -o <output-file>
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,11 @@ strip-json-comments < input-file > output-file
 ```
 
 
+## Related
+
+- [`strip-css-comments`](https://github.com/sindresorhus/strip-css-comments)
+
+
 ## License
 
 MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@
 var assert = require('assert');
 var strip = require('./strip-json-comments');
 
-describe('Test Cases', function() {
+describe('Test Cases', function () {
 	it('should strip comments', function () {
 		assert.strictEqual(strip('//comment\n{"a":"b"}'), '\n{"a":"b"}');
 		assert.strictEqual(strip('/*//comment*/{"a":"b"}'), '{"a":"b"}');
@@ -18,23 +18,25 @@ describe('Test Cases', function() {
 		assert.strictEqual(strip('{"\\"/*a":"b"}'), '{"\\"/*a":"b"}');
 	});
 
-	describe('Line endings', function() {
-		it('no comments', function() {
+	describe('Line endings', function () {
+		it('no comments', function () {
 			assert.strictEqual(strip('{"a":"b"\n}'), '{"a":"b"\n}');
 			assert.strictEqual(strip('{"a":"b"\r\n}'), '{"a":"b"\r\n}');
 		});
-		it('single line comment', function() {
+
+		it('single line comment', function () {
 			assert.strictEqual(strip('{"a":"b"//c\n}'), '{"a":"b"\n}');
 			assert.strictEqual(strip('{"a":"b"//c\r\n}'), '{"a":"b"\r\n}');
 		});
-		it('single line block comment', function() {
+
+		it('single line block comment', function () {
 			assert.strictEqual(strip('{"a":"b"/*c*/\n}'), '{"a":"b"\n}');
 			assert.strictEqual(strip('{"a":"b"/*c*/\r\n}'), '{"a":"b"\r\n}');
 		});
-		it('multi line block comment', function() {
+
+		it('multi line block comment', function () {
 			assert.strictEqual(strip('{"a":"b",/*c\nc2*/"x":"y"\n}'), '{"a":"b","x":"y"\n}');
 			assert.strictEqual(strip('{"a":"b",/*c\r\nc2*/"x":"y"\r\n}'), '{"a":"b","x":"y"\r\n}');
 		});
 	});
 });
-


### PR DESCRIPTION
Update CLI to allow explicit naming of input and output files. Useful for IDEs that use file watchers such as WebStorm/PhpStorm.