### PR TITLE
Rhino compatibility

### DIFF
--- a/strip-json-comments.js
+++ b/strip-json-comments.js
@@ -5,7 +5,11 @@
 	by Sindre Sorhus
 	MIT License
 */
-(function () {
+
+/* global window */
+/* exported stripJsonComments */
+
+var stripJsonComments = (function () {
 	'use strict';
 
 	function stripJsonComments(str) {
@@ -64,4 +68,6 @@
 	} else if (typeof window !== 'undefined') {
 		window.stripJsonComments = stripJsonComments;
 	}
+
+	return stripJsonComments;
 })();

--- a/strip-json-comments.js
+++ b/strip-json-comments.js
@@ -61,7 +61,7 @@
 
 	if (typeof module !== 'undefined' && module.exports) {
 		module.exports = stripJsonComments;
-	} else {
+	} else if (typeof window !== 'undefined') {
 		window.stripJsonComments = stripJsonComments;
 	}
 })();


### PR DESCRIPTION
This will allow Rhino to access the method by simply running:
```js
js> load('strip-json-comments.js');
js> stripJsonComments('/*//comment*/{"a":"b"}')
{"a":"b"}
```