### PR TITLE
Use `this` in place of `window` for broader compatibility

### DIFF
--- a/strip-json-comments.js
+++ b/strip-json-comments.js
@@ -62,6 +62,6 @@
 	if (typeof module !== 'undefined' && module.exports) {
 		module.exports = stripJsonComments;
 	} else {
-		window.stripJsonComments = stripJsonComments;
+		this.stripJsonComments = stripJsonComments;
 	}
 })();


### PR DESCRIPTION
This change does not affect existing functionality in any way, but it does allow a Rhino instance to load and use the script.

This is largely to address CSSLint/csslint#475, enabling `.csslintrc` files to have comments, just as `.jshintrc` files can.

This is a follow-up to #18.