### PR TITLE
Use an integer value for comment types instead of strings

### DIFF
--- a/strip-json-comments.js
+++ b/strip-json-comments.js
@@ -8,6 +8,9 @@
 (function () {
 	'use strict';
 
+	var singleComment = 1;
+	var multiComment = 2;
+
 	function stripJsonComments(str) {
 		var currentChar;
 		var nextChar;
@@ -32,21 +35,21 @@
 			}
 
 			if (!insideComment && currentChar + nextChar === '//') {
-				insideComment = 'single';
+				insideComment = singleComment;
 				i++;
-			} else if (insideComment === 'single' && currentChar + nextChar === '\r\n') {
+			} else if (insideComment === singleComment && currentChar + nextChar === '\r\n') {
 				insideComment = false;
 				i++;
 				ret += currentChar;
 				ret += nextChar;
 				continue;
-			} else if (insideComment === 'single' && currentChar === '\n') {
+			} else if (insideComment === singleComment && currentChar === '\n') {
 				insideComment = false;
 			} else if (!insideComment && currentChar + nextChar === '/*') {
-				insideComment = 'multi';
+				insideComment = multiComment;
 				i++;
 				continue;
-			} else if (insideComment === 'multi' && currentChar + nextChar === '*/') {
+			} else if (insideComment === multiComment && currentChar + nextChar === '*/') {
 				insideComment = false;
 				i++;
 				continue;


### PR DESCRIPTION
Use an integer value for comment types instead of strings, resulting in slightly faster comparisons. 