### PR TITLE
Fix #36

### DIFF
--- a/expect.json
+++ b/expect.json
@@ -1,0 +1,7 @@
+
+{
+   "scripts": {
+      
+     "tail": "ssh some_host \"tail -f some_file | sed -e \\\"s/^.\\\\{46\\\\}T//\\\" -e \\\"s/#033/\\\\x1b/g\\\"\""
+   }
+ }

--- a/index.js
+++ b/index.js
@@ -4,6 +4,18 @@ const multiComment = 2;
 const stripWithoutWhitespace = () => '';
 const stripWithWhitespace = (str, start, end) => str.slice(start, end).replace(/\S/g, ' ');
 
+const isEscaped = (str, qoutePos) => {
+	let i = qoutePos - 1;
+	let numOfBackslash = 0;
+
+	while (str[i] === '\\') {
+		numOfBackslash += 1;
+		i -= 1;
+	}
+
+	return Boolean(numOfBackslash % 2);
+};
+
 module.exports = (str, opts) => {
 	opts = opts || {};
 
@@ -19,7 +31,7 @@ module.exports = (str, opts) => {
 		const nextChar = str[i + 1];
 
 		if (!insideComment && currentChar === '"') {
-			const escaped = str[i - 1] === '\\' && str[i - 2] !== '\\';
+			const escaped = isEscaped(str, i);
 			if (!escaped) {
 				insideString = !insideString;
 			}

--- a/test.js
+++ b/test.js
@@ -60,7 +60,16 @@ test('line endings - works at EOF', t => {
 	t.is(m('{\r\n\t"a":"b"\r\n} //EOF', opts), '{\r\n\t"a":"b"\r\n} ');
 });
 
-test.failing('handles weird escaping', t => {
-	// eslint-disable-next-line no-useless-escape
-	t.is(m('{"x":"x \"sed -e \\\"s/^.\\\\{46\\\\}T//\\\" -e \\\"s/#033/\\\\x1b/g\\\"\""}'), '{"x":"x \"sed -e \\\"s/^.\\\\{46\\\\}T//\\\" -e \\\"s/#033/\\\\x1b/g\\\"\""}');
+test('handles weird escaping - read files', t => {
+	const opts = {whitespace: false};
+	const fs = require('fs');
+	const weirdData = fs.readFileSync(`${__dirname}/weird.json`, 'utf8');
+	const expectedData = fs.readFileSync(`${__dirname}/expect.json`, 'utf8');
+
+	t.is(m(weirdData, opts), expectedData);
+});
+
+test('handles weird escaping - string literals', t => {
+	const weirdData = '{"x":"x \\"sed -e \\\\\\"s/^.\\\\\\\\{46\\\\\\\\}T//\\\\\\" -e \\\\\\"s/#033/\\\\\\\\x1b/g\\\\\\"\\""}';
+	t.is(m(weirdData), weirdData);
 });

--- a/weird.json
+++ b/weird.json
@@ -1,0 +1,8 @@
+// From: https://github.com/sindresorhus/strip-json-comments/issues/36.
+{
+   "scripts": {
+      // The following should not be processed.
+     "tail": "ssh some_host \"tail -f some_file | sed -e \\\"s/^.\\\\{46\\\\}T//\\\" -e \\\"s/#033/\\\\x1b/g\\\"\""
+   }
+ }
+// Start of line comment should be removed.


### PR DESCRIPTION
Hi contributors of `strip-json-comments`, the following is my solution to #36.

### Caveat of JavaScript string 
> To include backslashs in a string, we need escape them.

For example, If we want our string `str` include two backslash, we should assign `str` with `'\\\\'`, but not the `'\\'`. Now back to the [failing testcase][1], If we want `str` be:
`{"x":"x \"sed -e \\\"s/^.\\\\{46\\\\}T//\\\" -e \\\"s/#033/\\\\x1b/g\\\"\""}`, 
we should assign `str` in this way:
```javascript
   str = '{"x":"x \\"sed -e \\\\\\"s/^.\\\\\\\\{46\\\\\\\\}T//\\\\\\" -e \\\\\\"s/#033/\\\\\\\\x1b/g\\\\\\"\\""}'
   // Actual value: {"x":"x \"sed -e \\\"s/^.\\\\{46\\\\}T//\\\" -e \\\"s/#033/\\\\x1b/g\\\"\""}
```
instead of:
```javascript
   str = '{"x":"x \"sed -e \\\"s/^.\\\\{46\\\\}T//\\\" -e \\\"s/#033/\\\\x1b/g\\\"\""}'
   // Actual value: {"x":"x "sed -e \"s/^.\\{46\\}T//\" -e \"s/#033/\\x1b/g\"""} 
```

### How to determine whether a quote is escaped or not

The [original solution][2] is `str[i - 1] === '\\' && str[i - 2] !== '\\'`, where `i` is the position of quote.
I think this is not enough, for example in `'\\\"'`, the `"` should be treated as ***escaped***. So to make right decision, we need count the number of  backslash backwards from the position of quote.
```javascript
function isEscaped (str, qoutePos) {
   let i = qoutePos - 1;
   let numOfBackslash = 0;

   while (str[i] === '\\') {
      numOfBackslash += 1;
      i -= 1;
   }

   // If numOfBackslash is an even, then the quote is not escaped; Otherwise escaped.
   return !!(numOfBackslash % 2);
};
```
[1]: https://github.com/sindresorhus/strip-json-comments/blob/master/test.js#L65
[2]: https://github.com/sindresorhus/strip-json-comments/blob/master/index.js#L22