### PR TITLE
Add `jsonc` to package.json keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
 		"settings",
 		"util",
 		"env",
-		"environment"
+		"environment",
+		"jsonc"
 	],
 	"devDependencies": {
 		"ava": "^1.4.1",


### PR DESCRIPTION
jsonc is a mode name in Visual Studio Code, referring to JSON with Comments.

See: https://code.visualstudio.com/docs/languages/json#_json-with-comments

GitHub’s Markdown also supports \`\`\`jsonc syntax, which highlights code like JSON, but without red markings on comments.

```json
{ /* json */ }
```

```jsonc
{ /* jsonc */ }
```

While looking for a module to parse jsonc, at first I could not find a suitable library. Then I searched npm for JSON comments, then found this module. I think adding `jsonc` to keywords would help with discoverability.

Note: This is not related to [Jsonc proposal](https://komkom.github.io/).