### PR TITLE
Switch to a `string.replace` approach

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -17,3 +17,8 @@ bench('strip JSON comments without whitespace', () => {
 bench('strip Big JSON comments', () => {
 	stripJsonComments(bigJson);
 });
+
+bench('avoids quadratic slowdowns', () => {
+	stripJsonComments('"\\'.repeat(10_000));
+	stripJsonComments('/* '.repeat(10_000));
+});

--- a/index.js
+++ b/index.js
@@ -11,10 +11,14 @@ export default function stripJsonComments(jsonString, {whitespace = true} = {}) 
 	// as strings, not comments, so we can just skip the whole string
 	// in the replacer function.
 	return jsonString.replace(
-		/"(?:[^"\\]|\\.)*"|\/\/[^\r\n]*|\/\*(?:[^*]|\*[^/])*\*\//g, match =>
-			// Skip strings:
-			match[0] === '"' ? match
-				// Replace comments with whitespace (or not):
-				: (whitespace ? match.replace(/\S/g, ' ') : ''),
+		/"(?:[^"\\]|\\.)*"?|\/\/[^\r\n]*|\/\*(?:[^*]|\*[^/])*(?:\*\/)?/g, match => {
+			// Skip strings & broken block comments:
+			if (match[0] === '"' || (match[1] === '*' && match.slice(-2) !== '*/')) {
+				return match;
+			}
+
+			// Replace comments with whitespace (or not):
+			return whitespace ? match.replace(/\S/g, ' ') : '';
+		},
 	);
 }

--- a/index.js
+++ b/index.js
@@ -1,77 +1,20 @@
-const singleComment = Symbol('singleComment');
-const multiComment = Symbol('multiComment');
-
-const stripWithoutWhitespace = () => '';
-const stripWithWhitespace = (string, start, end) => string.slice(start, end).replace(/\S/g, ' ');
-
-const isEscaped = (jsonString, quotePosition) => {
-	let index = quotePosition - 1;
-	let backslashCount = 0;
-
-	while (jsonString[index] === '\\') {
-		index -= 1;
-		backslashCount += 1;
-	}
-
-	return Boolean(backslashCount % 2);
-};
-
 export default function stripJsonComments(jsonString, {whitespace = true} = {}) {
 	if (typeof jsonString !== 'string') {
 		throw new TypeError(`Expected argument \`jsonString\` to be a \`string\`, got \`${typeof jsonString}\``);
 	}
 
-	const strip = whitespace ? stripWithWhitespace : stripWithoutWhitespace;
-
-	let isInsideString = false;
-	let isInsideComment = false;
-	let offset = 0;
-	let result = '';
-
-	for (let index = 0; index < jsonString.length; index++) {
-		const currentCharacter = jsonString[index];
-		const nextCharacter = jsonString[index + 1];
-
-		if (!isInsideComment && currentCharacter === '"') {
-			const escaped = isEscaped(jsonString, index);
-			if (!escaped) {
-				isInsideString = !isInsideString;
-			}
-		}
-
-		if (isInsideString) {
-			continue;
-		}
-
-		if (!isInsideComment && currentCharacter + nextCharacter === '//') {
-			result += jsonString.slice(offset, index);
-			offset = index;
-			isInsideComment = singleComment;
-			index++;
-		} else if (isInsideComment === singleComment && currentCharacter + nextCharacter === '\r\n') {
-			index++;
-			isInsideComment = false;
-			result += strip(jsonString, offset, index);
-			offset = index;
-			continue;
-		} else if (isInsideComment === singleComment && currentCharacter === '\n') {
-			isInsideComment = false;
-			result += strip(jsonString, offset, index);
-			offset = index;
-		} else if (!isInsideComment && currentCharacter + nextCharacter === '/*') {
-			result += jsonString.slice(offset, index);
-			offset = index;
-			isInsideComment = multiComment;
-			index++;
-			continue;
-		} else if (isInsideComment === multiComment && currentCharacter + nextCharacter === '*/') {
-			index++;
-			isInsideComment = false;
-			result += strip(jsonString, offset, index + 1);
-			offset = index + 1;
-			continue;
-		}
-	}
-
-	return result + (isInsideComment ? strip(jsonString.slice(offset)) : jsonString.slice(offset));
+	// This regular expression translates to:
+	//
+	//   /quoted-string|line-comment|block-comment/g
+	//
+	// This means that comment characters inside of strings will match
+	// as strings, not comments, so we can just skip the whole string
+	// in the replacer function.
+	return jsonString.replace(
+		/"(?:[^"\\]|\\.)*"|\/\/[^\r\n]*|\/\*(?:[^*]|\*[^/])*\*\//g, match =>
+			// Skip strings:
+			match[0] === '"' ? match
+				// Replace comments with whitespace (or not):
+				: (whitespace ? match.replace(/\S/g, ' ') : ''),
+	);
 }

--- a/test.js
+++ b/test.js
@@ -63,3 +63,7 @@ test('line endings - works at EOF', t => {
 test('handles weird escaping', t => {
 	t.is(stripJsonComments(String.raw`{"x":"x \"sed -e \\\"s/^.\\\\{46\\\\}T//\\\" -e \\\"s/#033/\\\\x1b/g\\\"\""}`), String.raw`{"x":"x \"sed -e \\\"s/^.\\\\{46\\\\}T//\\\" -e \\\"s/#033/\\\\x1b/g\\\"\""}`);
 });
+
+test('handles multiple comments in one input', t => {
+	t.is(stripJsonComments('// array:\n[1, /* 2 */, 3, /* todo... */] // end'), '         \n[1,        , 3,              ]       ');
+});

--- a/test.js
+++ b/test.js
@@ -67,3 +67,7 @@ test('handles weird escaping', t => {
 test('handles multiple comments in one input', t => {
 	t.is(stripJsonComments('// array:\n[1, /* 2 */, 3, /* todo... */] // end'), '         \n[1,        , 3,              ]       ');
 });
+
+test('handles malformed block comments', t => {
+	t.is(stripJsonComments('[] /*'), '[] /*');
+});


### PR DESCRIPTION
This approach is vastly simpler and faster, since it leverages the regular expression engine to to most of the work.

To handle comments inside of strings, simply search for strings as well, but then leave the strings as-is in the replacer function.

The benchmarks do run quite a bit faster:

- strip JSON comments is 80% faster
- strip JSON comments without whitespace is 180% faster
- strip Big JSON comments is 50% faster